### PR TITLE
Added Stripe API Versioning

### DIFF
--- a/stripe.cabal
+++ b/stripe.cabal
@@ -1,5 +1,5 @@
 Name:                stripe
-Version:             0.3.0.1
+Version:             0.3.1.1
 Synopsis:            A Haskell implementation of the Stripe API.
 Description:         This is an implementation of the Stripe API as it is
                      documented at https://stripe.com/docs/api
@@ -32,9 +32,9 @@ Library
                         , aeson         >= 0.6.1
                         , unordered-containers >= 0.1.4.6
                         , time          >= 1.0
-                        , http-conduit  >= 1.4.1.2
+                        , http-conduit  >= 1.4.1.2 && < 2.0.0
                         , http-types    >= 0.6.11
                         , bytestring    >= 0.9
                         , mtl           >= 2.1
                         , utf8-string   >= 0.3.7
-    extensions:         OverloadedStrings, TupleSections
+    extensions:         OverloadedStrings, TupleSections, RecordWildCards


### PR DESCRIPTION
This commit adds basic versioning support to hs-stripe

Highlights:
- RecordWildCards extension was added in an attempt to tidy up things. 
- Put upper bound on http-conduits (http-conduits > 2.0.0 is a breaking change)
- Defaults Stripe API to the version it was built against ("2011-09-15-d", Need feedback on this one...)

In http-conduits versions 2.0.0 and greater the kind of Request is now \* instead of \* -> *. Even more impetus for replacing http-conduits w/ io-streams. Which can be done once I get more time.

If imports are switched around that's due to my emacs configurations and the stylish-haskell plugin.

Other than that it was not a fundamental change and cards are working fine for me.
