### PR TITLE
cardCountry should be Maybe Text, as Stripe can return null from api

### DIFF
--- a/src/Web/Stripe/Card.hs
+++ b/src/Web/Stripe/Card.hs
@@ -17,7 +17,7 @@ import           Web.Stripe.Utils    (optionalArgs, showByteString,
 -- | Represents a credit card in the Stripe system.
 data Card = Card
     { cardType     :: T.Text
-    , cardCountry  :: T.Text
+    , cardCountry  :: Maybe T.Text
     , cardLastFour :: T.Text
     , cardExpMonth :: Int
     , cardExpYear  :: Int


### PR DESCRIPTION
The api can (at old points too, including the 2011 version) return null for the country field, which causes a JSON parse error (see issue #12).
