### PR TITLE
Added fingerprint field to Card constructor, bumped to 0.8.0

### DIFF
--- a/src/Web/Stripe/Card.hs
+++ b/src/Web/Stripe/Card.hs
@@ -18,12 +18,13 @@ import           Web.Stripe.Utils    (optionalArgs, showByteString,
 
 -- | Represents a credit card in the Stripe system.
 data Card = Card
-    { cardType     :: T.Text
-    , cardCountry  :: Maybe T.Text
-    , cardLastFour :: T.Text
-    , cardExpMonth :: Int
-    , cardExpYear  :: Int
-    , cardChecks   :: CardChecks
+    { cardType        :: T.Text
+    , cardCountry     :: Maybe T.Text
+    , cardLastFour    :: T.Text
+    , cardExpMonth    :: Int
+    , cardExpYear     :: Int
+    , cardFingerprint :: T.Text
+    , cardChecks      :: CardChecks
     } deriving Show
 
 -- | Represents a credit car (with full details) that is used as input to the
@@ -84,6 +85,7 @@ instance FromJSON Card where
     <*> v .:  "last4"
     <*> v .:  "exp_month"
     <*> v .:  "exp_year"
+    <*> v .:  "fingerprint"
     <*> (CardChecks
       <$> v .: "cvc_check"
       <*> v .: "address_line1_check"

--- a/stripe.cabal
+++ b/stripe.cabal
@@ -1,5 +1,5 @@
 Name:                stripe
-Version:             0.7.0
+Version:             0.8.0
 Synopsis:            A Haskell implementation of the Stripe API.
 Description:         This is an implementation of the Stripe API as it is
                      documented at https:\/\/stripe.com\/docs\/api


### PR DESCRIPTION
The API has a "fingerprint" field inside a Card object that uniquely identifies a card. This allows consumers of the API to deny credit cards based on the fingerprint, while maintaining PCI compliance. No reason not to have it. I'm going to use it to patch a hole in the referral system I'm building.

From the docs.

> You can use the fingerprint parameter that's available on a charge object's nested card or a customer object's active_card to uniquely identify a card in your account. If you've decided that you'd like to block a certain card, you  can safely detect it based on the fingerprint.[/quote]
> https://support.stripe.com/questions/blocking-certain-card-numbers
> 
> ``` haskell
> Card  { cardType = "Visa", 
>            ,cardCountry = Just "US"
>            ,cardLastFour = "4242"
>            ,cardExpMonth = 9
>            , cardExpYear = 2014
>            ,cardFingerprint = "vVbWfR9fR23vbUPw" -- works for me
>            ,cardChecks = CardChecks {
>                               checkCVC = Passed
>                               , checkAddrLineOne = Passed
>                               , checkZip = Passed
>                               }
>           }
> ```
