### PR TITLE
Make "fingerprint" field optional for Card

### DIFF
--- a/src/Web/Stripe/Card.hs
+++ b/src/Web/Stripe/Card.hs
@@ -28,7 +28,7 @@ data Card = Card
     , cardLastFour    :: T.Text
     , cardExpMonth    :: Int
     , cardExpYear     :: Int
-    , cardFingerprint :: T.Text
+    , cardFingerprint :: Maybe T.Text
     , cardChecks      :: CardChecks
     } deriving Show
 
@@ -91,7 +91,7 @@ instance FromJSON Card where
     <*> v .:  "last4"
     <*> v .:  "exp_month"
     <*> v .:  "exp_year"
-    <*> v .:  "fingerprint"
+    <*> v .:?  "fingerprint"
     <*> (CardChecks
       <$> v .: "cvc_check"
       <*> v .: "address_line1_check"


### PR DESCRIPTION
From Stripe: Publishable keys can no longer be used to retrieve token objects. When a card or bank account token is created with a publishable key, the fingerprint property is no longer included in the response.
https://stripe.com/docs/upgrades