### PR TITLE
Change updateSubToken to use "card" parameter instead of "token" parameter

### DIFF
--- a/src/Web/Stripe/Subscription.hs
+++ b/src/Web/Stripe/Subscription.hs
@@ -98,7 +98,7 @@ updateSubRCard  = updateSub . rCardKV
 updateSubToken :: MonadIO m => TokenId -> CustomerId -> PlanId -> Maybe CpnId
                -> Maybe SubProrate -> Maybe SubTrialEnd
                -> StripeT m Subscription
-updateSubToken (TokenId tid) = updateSub [("token", textToByteString tid)]
+updateSubToken (TokenId tid) = updateSub [("card", textToByteString tid)]
 
 
 -- | Create a new 'Subscription'. Limitations: does not yet support passing


### PR DESCRIPTION
Pursuant to Stripe API specification at https://stripe.com/docs/api#update_subscription
